### PR TITLE
Update market_engine.hpp and market_engine.cpp

### DIFF
--- a/libraries/blockchain/include/bts/blockchain/market_engine.hpp
+++ b/libraries/blockchain/include/bts/blockchain/market_engine.hpp
@@ -47,6 +47,8 @@ namespace bts { namespace blockchain { namespace detail {
       *  is for historical purposes only.
       */
     void update_market_history( const asset& trading_volume,
+                                const price& highest_price,
+                                const price& lowest_price,
                                 const price& opening_price,
                                 const price& closing_price,
                                 const fc::time_point_sec timestamp );


### PR DESCRIPTION
Fix issues about update_market_history:
* Update highest price and lowest price of matched orders to market history, rather than those of open orders
* Always update hourly and daily market history data if volume changed