### PR TITLE
[bts-test] Unable to issue restricted asset

### DIFF
--- a/tests/btstests/advanced_uia/issue_restricted_uia_exception/issue_restricted_uia_exception.btstest
+++ b/tests/btstests/advanced_uia/issue_restricted_uia_exception/issue_restricted_uia_exception.btstest
@@ -1,0 +1,103 @@
+>>> !client alice
+>>> debug_start_simulated_time "20140620T144030.000000"
+OK
+>>> wallet_create default "password"
+OK
+>>> wallet_set_automatic_backups false
+false
+>>> debug_deterministic_private_keys 0 101 init true
+[ ${ expect_regex(r'(?:\s*"[a-zA-Z0-9]+"[,]?){101}') }$ ]
+>>> wallet_delegate_set_block_production ALL true
+OK
+>>> wallet_set_transaction_scanning true
+true
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 1
+OK
+>>> wallet_account_create issuer
+"XTS ${ expect_regex(r'[a-zA-Z0-9]+') }$"
+>>> wallet_account_balance myaccount
+No balances found.
+>>> debug_deterministic_private_keys 0 6 alice true issuer false true
+[ ${ expect_regex(r'(?:\s*"[a-zA-Z0-9]+"[,]?){6}') }$ ]
+>>> wallet_account_balance issuer
+ACCOUNT                         BALANCE                     
+============================================================
+issuer                       600,000.00000 XTS
+>>> blockchain_get_account issuer
+No account found.
+>>> wallet_account_register issuer issuer
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID      
+======================================================================================================================================================================
+2014-06-20T14:40:30 PENDING   issuer              issuer              0.00000 XTS             register issuer                             0.50000 XTS         3577f090
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 2
+OK
+>>> wallet_asset_create ASSET "Test Asset" issuer "A test asset" 10000000 1000 {} false
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2015-06-20T14:40:40 PENDING   issuer              issuer              0.00000 XTS             create ASSET (Test Asset)                   500,000.50000 XTS   d2faa4a6
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 3
+OK
+>>> wallet_asset_update ASSET null null null null null 0 -1 ["restricted"] ["restricted","retractable","market_halt","balance_halt"] "" 0 []
+${ expect_json() }$
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 4
+OK
+>>> wallet_account_create customer
+"XTS ${ expect_regex(r'[a-zA-Z0-9]+') }$"
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 5
+OK
+>>> wallet_account_register customer issuer
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2015-03-05T00:44:36 PENDING   issuer              customer            0.00000 XTS             register customer                           0.50000 XTS         12f601f0
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 6
+OK
+#{ inserts owner address into the whitelist }#
+>>> wallet_asset_authorize_key issuer ASSET customer
+${ expect_json() }$
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 7
+OK
+#{
+   issuing a restricted asset to authorized account name throws an Assert Exception
+   is_authorized() fails at balance_records::deposit_operation:145
+   looking up the using the memory address of addr always fails. Even for the ASSET issuer
+   Is it possibly because type address is inserted into whitelist in authorize_operation
+   but the whitelist.count comparison on line 145 uses type &address?
+}#
+>>> wallet_asset_issue 1111 ASSET customer
+10 assert_exception: Assert Exception
+asset_rec->is_authorized(owner):
+    {}
+    th_a  balance_operations.cpp:145 evaluate
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 8
+#{ ASSET issuer cant issue restricted to self either }#
+>>> wallet_asset_issue 1111 ASSET issuer
+10 assert_exception: Assert Exception
+asset_rec->is_authorized(owner):
+    {}
+    th_a  balance_operations.cpp:145 evaluate
+#{ set state to "restricted" and whitelist a customer }#
+#{  set state to "retractable" and retract his balance }#
+#{  set state to "market_halt" and make sure the market is halted }#
+#{  set state to "balance_halt" and make sure nobody can transact }#
+
+#{  remove "restricted" permission and check that there are no restrictions }#
+#{  remove "retractable" permission and check that you can't retract balances }#
+#{  remove "supply_unlimit" permission and check that you can't print shares }#
+#{  remove "market_halt" permission and make sure you can't set that state anymore }#
+#{  remove "balance_halt" permission and make sure you can't set that state anymore }#

--- a/tests/btstests/advanced_uia/issue_restricted_uia_exception/testenv
+++ b/tests/btstests/advanced_uia/issue_restricted_uia_exception/testenv
@@ -1,0 +1,16 @@
+
+with _btstest.ClientProcess(name="alice") as p_alice:
+    # create client process
+    rpc_client = _btstest.RPCClient(dict(
+        host="127.0.0.1",
+        port=p_alice.http_port,
+        rpc_user=p_alice.username,
+        rpc_password=p_alice.password,
+        ))
+    test_client = _btstest.TestClient("alice", rpc_client)
+    register_client(test_client)
+    rpc_client.wait_for_rpc()
+    # active_client = "alice"
+
+    run_testdir(my_path)
+


### PR DESCRIPTION
Issuing a restricted asset to an account authorized with wallet_asset_authorize_key
fails because the deposit_operation obalance_record's owner address isnt found in the UIA whitelist
at asset_record::is_authorized.

Is it possibly because type address is inserted into whitelist in authorize_operation
but the whitelist.count comparison on line 145 uses type &address?