### PR TITLE
[btstest] test new UIA API functionality

### DIFF
--- a/tests/btstests/advanced_uia/advanced_uia_tests/advanced_uia.btstest
+++ b/tests/btstests/advanced_uia/advanced_uia_tests/advanced_uia.btstest
@@ -1,211 +1,229 @@
 >>> !client alice
+>>> !expect disable
 >>> debug_start_simulated_time "20140620T144030.000000"
 OK
+
 >>> wallet_create default "password"
 OK
+
 >>> wallet_set_automatic_backups false
 false
+
 >>> debug_deterministic_private_keys 0 101 init true
 [ ${ expect_regex(r'(?:\s*"[a-zA-Z0-9]+"[,]?){101}') }$ ]
+
 >>> wallet_delegate_set_block_production ALL true
 OK
+
 >>> wallet_set_transaction_scanning true
 true
+
 >>> debug_wait_for_block_by_number 1
 OK
+
 >>> wallet_account_create issuer
 ${ expect_regex(r'(?:\s*"[a-zA-Z0-9]+"[,]?){101}') }$
+
 >>> wallet_account_balance issuer
 No balances found.
+
 >>> debug_deterministic_private_keys 0 1 alice true issuer false true
 [
   "5HpUwrtzSztqQpJxVHLsrZkVzVjVv9nUXeauYeeSxguzcmpgRcK"
 ]
+
 >>> wallet_account_balance issuer
 ACCOUNT                         BALANCE                     
 ============================================================
-issuer                          100,000.00000 XTS           
+issuer                          100,000.00000 XTS
+
 >>> blockchain_get_account issuer
 No account found.
+
 >>> wallet_account_register issuer issuer
 TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID      
 ======================================================================================================================================================================
 2014-06-20T14:40:30 PENDING   issuer              issuer              0.00000 XTS             register issuer                             0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> wallet_account_list_public_keys issuer
+${ expect_json() }$
+
 >>> wallet_account_create someone
 ${ expect_regex(r'(?:\s*"[a-zA-Z0-9]+"[,]?){101}') }$
+
 >>> debug_deterministic_private_keys 1 1 alice true someone false true
 [
   "5JuNNRpMexdnkHMn5RocYnKePjmHB8HHoaEuYWFHxC8eH4ELWi7"
 ]
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 2
+
+>>> wallet_account_list_public_keys someone
+${ expect_json() }$
+
 >>> wallet_account_register someone issuer
 TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID      
 ======================================================================================================================================================================
 2014-06-20T14:40:30 PENDING   issuer              someone             0.00000 XTS             register someone                            0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
 ${ expect_regex(r'(?:\s*"[a-zA-Z0-9]+"[,]?){101}') }$
->>> debug_advance_time 1 block
-OK
->>> debug_wait_for_block_by_number 2
-OK
->>> wallet_uia_create issuer ASSSET "Test Asset" "A test asset" 10000.000
-TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID      
-======================================================================================================================================================================
-2014-06-20T14:40:40 PENDING   issuer              issuer              0.00000 XTS             create ASSSET (Test Asset)                  5,000.50000 XTS     ${ expect_regex(r'[0-9a-f]*') }$
+
 >>> debug_advance_time 1 block
 OK
 >>> debug_wait_for_block_by_number 3
 OK
->>> blockchain_get_asset ASSSET
-{
-  "id": 4,
-  "symbol": "ASSSET",
-  "name": "Test Asset",
-  "description": "A test asset",
-  "public_data": {},
-  "issuer_account_id": 102,
-  "precision": 1000,
-  "registration_date": "2014-06-20T14:40:40",
-  "last_update": "2014-06-20T14:40:40",
-  "maximum_share_supply": 10000000000,
-  "current_share_supply": 0,
-  "collected_fees": 0,
-  "flags": 0,
-  "issuer_permissions": 31,
-  "transaction_fee": 0,
-  "market_fee": 0,
-  "authority": {
-    "required": 1,
-    "owners": [
-      ${ expect_regex(r'(?:\s*"[a-zA-Z0-9]+"[,]?){101}') }$
-    ]
-  },
-  "whitelist": []
-}
->>> help wallet_uia_update_description
+
+>>> help wallet_uia_create
 Usage:
-Updates an existing user-issued asset; only the public_data can be updated if any shares of the asset exist
+wallet_uia_create <issuer_account> <symbol> <name> <description> <max_supply_with_trailing_decimals>   Create a new user-issued asset on the blockchain. Warning: creation fees can be very high!
+Create a new user-issued asset on the blockchain. Warning: creation fees can be very high!
 
 Parameters:
-  symbol (asset_symbol, required): the ticker symbol for the asset to update
-  name (optional_string, optional, defaults to null): the new name to give the asset; or null to keep the current name
-  description (optional_string, optional, defaults to null): the new description to give the asset; or null to keep the current description
-  public_data (optional_variant, optional, defaults to null): the new public_data to give the asset; or null to keep the current public_data
-  maximum_share_supply (optional_double, optional, defaults to null): the new maximum_share_supply to give the asset; or null to keep the current maximum_share_supply
-  precision (optional_uint64_t, optional, defaults to null): the new precision to give the asset; or null to keep the current precision
-  issuer_transaction_fee (share_type, optional, defaults to 0): an additional fee (denominated in issued asset) charged by the issuer on every transaction that uses this asset type
-  issuer_market_fee (real_amount, optional, defaults to -1): an additional fee (denominated in percent) charged by the issuer on every order that is matched
-  flags (asset_permission_array, optional, defaults to []): a set of flags set by the issuer (if they have permission to set them)
-  issuer_permissions (asset_permission_array, optional, defaults to ["restricted","retractable","market_halt","balance_halt","supply_unlimit"]): a set of permissions an issuer retains
-  issuer_account_name (account_name, optional, defaults to ""): used to transfer the asset to a new user
-  required_sigs (uint32_t, optional, defaults to 0): number of signatures from the authority required to control this asset record
-  authority (address_list, optional, defaults to []): owner keys that control this asset record
+  issuer_account (string, required): The registered account name that will pay the creation fee and control the new asset
+  symbol (asset_symbol, required): A unique symbol that will represent the new asset. Short symbols are very expensive!
+  name (string, required): A human-readable name for the new asset
+  description (string, required): A human-readable description of the new asset
+  max_supply_with_trailing_decimals (string, required): Choose the max share supply and max share divisibility for the new asset. For example: 10000000000.00000 or 12345.6789
+
+Returns:
+  transaction_record
+
+>>> wallet_uia_create issuer ASSSET "Test Asset" "A test asset" 10000.000
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID      
+======================================================================================================================================================================
+2014-06-20T14:40:40 PENDING   issuer              issuer              0.00000 XTS             create ASSSET (Test Asset)                  5,000.00000 XTS     ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+
+>>> debug_wait_for_block_by_number 4
+OK
+
+>>> blockchain_get_asset ASSSET
+${ expect_json() }$
+
+>>> help wallet_uia_update_description
+Usage:
+wallet_uia_update_description <paying_account> <asset_symbol> [name] [description] [public_data]      Update the name, description, public data of the specified user-issue asset
+Update the name, description, public data of the specified user-issue asset
+
+Parameters:
+  paying_account (account_name, required): the account that will pay the transaction fee
+  asset_symbol (asset_symbol, required): the user-issued asset to update
+  name (string, optional, defaults to ""): A human-readable name for the new asset
+  description (string, optional, defaults to ""): A human-readable description of the new asset
+  public_data (variant, optional, defaults to null): Extra data to attach to the asset
 
 Returns:
   transaction_record
 
 #{ name not empty }#
 >>> wallet_uia_update_description issuer ASSSET ""
-35011 invalid_asset_name: invalid asset name
-${ expect_regex(r'(?s).*') }$
+10 assert_exception: Assert Exception
+this->issuer_id.valid() || this->name.valid() || this->description.valid() || this->public_data.valid()
+|| this->precision.valid() || this->max_supply.valid() || this->withdrawal_fee.valid() || this->market_fee_rate.valid():
+
 >>> wallet_uia_update_description issuer ASSSET "Woot!"
-{
-  "index": 0,
-  "record_id": "${ expect_regex(r'[0-9a-f]*') }$",
-  "block_num": 0,
-  "is_virtual": false,
-  "is_confirmed": false,
-  "is_market": false,
-  "trx": {
-    "expiration": "2014-06-20T15:40:50",
-    "reserved": null,
-    "operations": [{
-        "type": "update_asset_ext_op_type",
-        "data": {
-          "asset_id": 4,
-          "name": "Woot!",
-          "description": "",
-          "public_data": null,
-          "maximum_share_supply": null,
-          "precision": null,
-          "flags": 0,
-          "issuer_permissions": 31,
-          "issuer_account_id": 102,
-          "transaction_fee": 0,
-          "market_fee": 55536,
-          "authority": {
-            "required": 0,
-            "owners": []
-          }
-        }
-      },{
-        "type": "withdraw_op_type",
-        "data": {
-          "balance_id": "XTSEUci2GH1cjDvCireCmeoukCitp8aru725",
-          "amount": 50000,
-          "claim_input_data": ""
-        }
-      }
-    ],
-    "signatures": [
-      "${ expect_regex(r'[0-9a-f]*') }$",
-      "${ expect_regex(r'[0-9a-f]*') }$"
-    ]
-  },
-  "ledger_entries": [{
-      "from_account": "${ expect_regex(r'[a-zA-Z0-9]+') }$",
-      "to_account": "${ expect_regex(r'[a-zA-Z0-9]+') }$",
-      "amount": {
-        "amount": 0,
-        "asset_id": 0
-      },
-      "memo": "update ASSSET asset",
-      "memo_from_account": null
-    }
-  ],
-  "fee": {
-    "amount": 50000,
-    "asset_id": 0
-  },
-  "created_time": "2014-06-20T14:40:50",
-  "received_time": "2014-06-20T14:40:50",
-  "extra_addresses": []
-}
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:40:50 PENDING   issuer              UNKNOWN             0.00000 XTS             update properties for ASSSET                0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 4
+OK
 
 #{ max shares > 0 && < 10^15 ??? }#
 >>> help wallet_uia_update_supply
->>> wallet_uia_update_supply issuer ASSSET -1
-35005 invalid_asset_amount: invalid asset amount
-${ expect_regex(r'(?s).*') }$
->>> wallet_uia_update_supply issuer ASSSET 100000000000.0001
-35005 invalid_asset_amount: invalid asset amount
-${ expect_regex(r'(?s).*') }$
->>> wallet_uia_update_supply issuer ASSSET 100000000000.0000
-${ expect_json() }$
-
->>> help wallet_uia_issue
 Usage:
-Issues new shares of a given asset type
-
+wallet_uia_update_supply <paying_account> <asset_symbol> <max_supply_with_trailing_decimals>          Update the max supply and max divisibility of the specified user-issued asset if permitted
+Update the max supply and max divisibility of the specified user-issued asset if permitted
 
 Parameters:
-  amount (real_amount, required): the amount of shares to issue
-  symbol (asset_symbol, required): the ticker symbol for asset
-  to_account_name (account_name, required): the name of the account to receive the shares
-  memo_message (string, optional, defaults to ""): the memo to send to the receiver
+  paying_account (account_name, required): the account that will pay the transaction fee
+  asset_symbol (asset_symbol, required): the user-issued asset to update
+  max_supply_with_trailing_decimals (string, required): Choose the max share supply and max share divisibility for the asset. For example: 10000000000.00000 or 12345.6789
 
 Returns:
   transaction_record
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 5
+OK
+
+#{ set negative supply }#
+>>> wallet_uia_update_supply issuer ASSSET -1
+35005 invalid_asset_amount: invalid asset amount
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 6
+OK
+
+#{ set supply above max }#
+>>> wallet_uia_update_supply issuer ASSSET 100000000000.0001
+35012 amount_too_large: amount too large
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 7
+OK
+
+#{ set supply to max }#
+>>> wallet_uia_update_supply issuer ASSSET 100000000000.0000
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:40:50 PENDING   issuer              UNKNOWN             0.00000 XTS             update properties for ASSSET                0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 8
+OK
+
+>>> help wallet_uia_issue
+Usage:
+wallet_uia_issue <asset_amount> <asset_symbol> <recipient> [memo_message]                             Issue shares of a user-issued asset to the specified recipient
+Issue shares of a user-issued asset to the specified recipient
+
+Parameters:
+  asset_amount (string, required): the amount of shares of the asset to issue
+  asset_symbol (asset_symbol, required): specify the unique symbol of the asset
+  recipient (string, required): the account name, public key, address, btc address, or contact label (prefixed by "label:") which will receive the funds
+  memo_message (string, optional, defaults to ""): a memo to send if the recipient is an account
+
+Returns:
+  transaction_record
+
 >>> wallet_uia_update_supply issuer ASSSET 100000.000
-${ expect_json() }$
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:40:50 PENDING   issuer              UNKNOWN             0.00000 XTS             update properties for ASSSET                0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 9
+OK
 
 #{ issue negative amount }#
 >>> wallet_uia_issue -100 ASSSET someone "There!"
 35006 negative_issue: negative issue
-${ expect_regex(r'(?s).*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 10
+OK
 
 #{ issue more than max shares }#
 >>> wallet_uia_issue 200000 ASSSET someone "There!"
 35007 over_issue: over issue
 ${ expect_regex(r'(?s).*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 11
+OK
 
 #{ issue some }#
 >>> wallet_uia_issue 2000 ASSSET someone "There!"
@@ -213,43 +231,207 @@ TIMESTAMP           BLOCK     FROM                TO                  AMOUNT    
 ======================================================================================================================================================================
 2014-06-20T14:40:50 PENDING   issuer              someone             2,000.000 ASSSET        issue 2,000.000 ASSSET                      0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
 
-#{ issue more than max total shares }#
->>> wallet_uia_issue 99000 ASSSET someone "There!"
-35007 over_issue: over issue
-${ expect_regex(r'(?s).*') }$
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 12
+OK
 
 #{ can't update precision if supply > 0 }#
->>> wallet_uia_issue ASSSET null null null null 10000
+>>> wallet_uia_update_supply issuer ASSSET 100000.00
 10 assert_exception: Assert Exception
 !this->precision.valid(): 
 ${ expect_regex(r'(?s).*') }$
->>> wallet_uia_issue ASSSET null null null null 100
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 13
+OK
+
+#{ try updating to higher precision }#
+>>> wallet_uia_update_supply issuer ASSSET 100000.0000
 10 assert_exception: Assert Exception
 !this->precision.valid(): 
 ${ expect_regex(r'(?s).*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 14
+OK
 
 #{ can't update max shares if supply > 0 && !flags.supply_unlimit }#
 >>> wallet_uia_update_supply issuer ASSSET 1000.000
-10 assert_exception: Assert Exception
-!this->maximum_share_supply.valid(): 
+35013 outstanding_shares_exist: outstanding shares exist
 ${ expect_regex(r'(?s).*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 15
+OK
+
 >>> help wallet_uia_update_active_flags
+Usage:
+wallet_uia_update_active_flags <paying_account> <asset_symbol> <flag> <enable_instead_of_disable>     Activate or deactivate one of the special flags for the specified user-issued asset as permitted
+Activate or deactivate one of the special flags for the specified user-issued asset as permitted
+
+Parameters:
+  paying_account (account_name, required): the account that will pay the transaction fee
+  asset_symbol (asset_symbol, required): the user-issued asset to update
+  flag (asset_flag_enum, required): the special flag to enable or disable; one of {dynamic_max_supply, dynamic_fees, halted_markets, halted_withdrawals, retractable_balances, restricted_deposits}
+  enable_instead_of_disable (bool, required): true to enable, or false to disable
+
+Returns:
+  transaction_record
 >>> wallet_uia_update_active_flags issuer ASSSET dynamic_max_supply true
-${ expect_json() }$
->>> wallet_uia_update_supply issuer ASSSET 1000.000
-10 assert_exception: Assert Exception
-current_share_supply >= 0 && current_share_supply <= maximum_share_supply: 
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:40:50 PENDING   issuer              UNKNOWN             0.00000 XTS             add dynamic_max_supply to authority perm... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 16
+OK
+
+#{ try to update max supply to value less than issued supply }#
+>>> wallet_uia_update_supply issuer ASSSET 1000.00
+35005 invalid_asset_amount: invalid asset amount
 ${ expect_regex(r'(?s).*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 17
+OK
+
+#{ test that precision cant be truncated with dynamic_max_supply }#
+>>> wallet_uia_update_supply issuer ASSSET 90000.00
+35013 outstanding_shares_exist: outstanding shares exist
+${ expect_regex(r'(?s).*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 18
+OK
+
+#{ update max supply to valid amount }#
 >>> wallet_uia_update_supply issuer ASSSET 90000.000
-${ expect_json() }$
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:40:50 PENDING   issuer              UNKNOWN             0.00000 XTS             update properties for ASSSET                0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 19
+OK
 
 #{ set "restricted" flag }#
->>> wallet_asset_update ASSSET null null null null null null null ["restricted","supply_unlimit"]
-${ expect_json() }$
-#{ send to unauthorized }#
+>>> wallet_uia_update_active_flags issuer ASSSET restricted_deposits true
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:41:30 PENDING   issuer              UNKNOWN             0.00000 XTS             add restricted_deposits to authority per... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 20
+OK
+
+#{ try issuing restricted shares to issuer }#
+>>> wallet_uia_issue 5555 ASSSET issuer
+10 assert_exception: Assert Exception
+asset_rec->address_is_whitelisted( owner ):
+
+#{ whitelist issuer }#
+>>> wallet_uia_update_whitelist issuer ASSSET XTS6MztcCwGPciDNLrodkGdXf33S6raovWDfVieYdNTg92eC45PDf true
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:43:50 PENDING   issuer              UNKNOWN             0.00000 XTS             add XTSBcMjERMjXoESq9zjCGBHsX3RbGhNFABUX... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 21
+OK
+
+#{ try issuing to account name of whitelisted public key }#
+>>> wallet_uia_issue 5555 ASSSET issuer
+10 assert_exception: Assert Exception
+asset_rec->address_is_whitelisted( owner ):
+
+#{ issue to pub key of issuer }#
+>>> wallet_uia_issue 5555 ASSSET XTS6MztcCwGPciDNLrodkGdXf33S6raovWDfVieYdNTg92eC45PDf
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:44:00 PENDING   issuer              ANONYMOUS           5,555.000 ASSSET                                                    0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 22
+OK
+>>> wallet_account_balance issuer
+ACCOUNT                         BALANCE
+============================================================
+issuer                          94,994.50000 XTS
+                                5,555.000 ASSSET
+#{ send to unauthorized account }#
+>>> wallet_transfer 100 ASSSET issuer someone
+10 assert_exception: Assert Exception
+asset_rec->address_is_whitelisted( owner ):
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 23
+OK
+
 #{ issue to unauthorized }#
-#{ authorize someone }#
-#{ send to authorized }#
+>>> wallet_uia_issue 100 ASSSET someone
+10 assert_exception: Assert Exception
+asset_rec->address_is_whitelisted( owner ):
+
+>>> help wallet_uia_update_whitelist
+Usage:
+wallet_uia_update_whitelist <paying_account> <asset_symbol> <address_or_public_key> <add_to_whitelist>   Add or remove the specified address or public key from the specified user-issued asset's whitelist
+Add or remove the specified address or public key from the specified user-issued asset's whitelist
+
+Parameters:
+  paying_account (account_name, required): the account that will pay the transaction fee
+  asset_symbol (asset_symbol, required): the user-issued asset that will have its whitelist updated
+  address_or_public_key (string, required): the address or public key to add or remove from the whitelist
+  add_to_whitelist (bool, required): true to add to whitelist, or false to remove
+
+Returns:
+  transaction_record
+
+#{ try to authorize someone by account name }#
+>>> wallet_uia_update_whitelist issuer ASSSET someone true
+10 assert_exception: Assert Exception
+is_valid( base58str ):
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 24
+OK
+
+#{ authorize someone by public key }#
+>>> wallet_uia_update_whitelist issuer ASSSET XTS59zAznbyRDBZDzKSDXjxwbbuge2W7heUajH3q7ChuyMoENQBNX true
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:44:20 PENDING   issuer              UNKNOWN             0.00000 XTS             add XTS2yB9xPhVuQwEXe6BxM78sbXXRoKJmw2R9... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 25
+OK
+
+#{ try sending to authorized using wallet_transfer }#
+>>> wallet_transfer 100 ASSSET XTS6MztcCwGPciDNLrodkGdXf33S6raovWDfVieYdNTg92eC45PDf XTS59zAznbyRDBZDzKSDXjxwbbuge2W7heUajH3q7ChuyMoENQBNX
+20005 unknown_wallet_account: unknown local account
+
+>>> wallet_transfer 100 ASSSET issuer XTS59zAznbyRDBZDzKSDXjxwbbuge2W7heUajH3q7ChuyMoENQBNX
+36005 insufficient_relay_fee: insufficient relay fee
+
+>>> wallet_account_balance_ids issuer
+${ expect_json() }$
+#{ try sending to authorized via withdraw address to account authorized by public key }#
+>>> wallet_withdraw_from_address 100 ASSSET XTSEUci2GH1cjDvCireCmeoukCitp8aru725 someone
+10 assert_exception: Assert Exception
+asset_rec->address_is_whitelisted( owner ):
 #{ issue to authorized }#
 #{ authorize someone else }#
 #{ send from authorized to unauthorized }#

--- a/tests/btstests/advanced_uia/advanced_uia_tests/advanced_uia.btstest
+++ b/tests/btstests/advanced_uia/advanced_uia_tests/advanced_uia.btstest
@@ -334,7 +334,7 @@ OK
 OK
 
 #{ try issuing restricted shares to issuer }#
->>> wallet_uia_issue 5555 ASSSET issuer
+>>> wallet_uia_issue 55555 ASSSET issuer
 10 assert_exception: Assert Exception
 asset_rec->address_is_whitelisted( owner ):
 
@@ -350,12 +350,12 @@ OK
 OK
 
 #{ try issuing to account name of whitelisted public key }#
->>> wallet_uia_issue 5555 ASSSET issuer
+>>> wallet_uia_issue 55555 ASSSET issuer
 10 assert_exception: Assert Exception
 asset_rec->address_is_whitelisted( owner ):
 
 #{ issue to pub key of issuer }#
->>> wallet_uia_issue 5555 ASSSET XTS6MztcCwGPciDNLrodkGdXf33S6raovWDfVieYdNTg92eC45PDf
+>>> wallet_uia_issue 55555 ASSSET XTS6MztcCwGPciDNLrodkGdXf33S6raovWDfVieYdNTg92eC45PDf
 TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
 ======================================================================================================================================================================
 2014-06-20T14:44:00 PENDING   issuer              ANONYMOUS           5,555.000 ASSSET                                                    0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
@@ -368,7 +368,8 @@ OK
 ACCOUNT                         BALANCE
 ============================================================
 issuer                          94,994.50000 XTS
-                                5,555.000 ASSSET
+                                55,555.000 ASSSET
+
 #{ send to unauthorized account }#
 >>> wallet_transfer 100 ASSSET issuer someone
 10 assert_exception: Assert Exception
@@ -419,92 +420,147 @@ OK
 >>> debug_wait_for_block_by_number 25
 OK
 
-#{ try sending to authorized using wallet_transfer }#
->>> wallet_transfer 100 ASSSET XTS6MztcCwGPciDNLrodkGdXf33S6raovWDfVieYdNTg92eC45PDf XTS59zAznbyRDBZDzKSDXjxwbbuge2W7heUajH3q7ChuyMoENQBNX
-20005 unknown_wallet_account: unknown local account
+#{ try sending to account with public key in whitelist }#
+>>> wallet_transfer 100 ASSSET issuer someone
+asset_rec->address_is_whitelisted( owner ):
+    {}
+    th_a  balance_operations.cpp:145 evaluate
+${ expect_regex(r'(?s).*') }$
 
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 26
+OK
+
+#{ try sending to public key of someone. Fee handling bugged?  }#
 >>> wallet_transfer 100 ASSSET issuer XTS59zAznbyRDBZDzKSDXjxwbbuge2W7heUajH3q7ChuyMoENQBNX
 36005 insufficient_relay_fee: insufficient relay fee
+${ expect_regex(r'(?s).*') }$
 
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 27
+OK
+
+#{ get balance ids for issuer }#
 >>> wallet_account_balance_ids issuer
 ${ expect_json() }$
+
 #{ try sending to authorized via withdraw address to account authorized by public key }#
 >>> wallet_withdraw_from_address 100 ASSSET XTSEUci2GH1cjDvCireCmeoukCitp8aru725 someone
 10 assert_exception: Assert Exception
 asset_rec->address_is_whitelisted( owner ):
-#{ issue to authorized }#
+
+#{ issue to someone authorized via public key }#
+>>> wallet_uia_issue 5555 ASSSET XTS59zAznbyRDBZDzKSDXjxwbbuge2W7heUajH3q7ChuyMoENQBNX
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 28
+OK
+
 #{ authorize someone else }#
+
 #{ send from authorized to unauthorized }#
 #{ send from authorized to authorized }#
 
 #{ set "retractable" flag }#
->>> wallet_asset_update ASSSET null null null null null null null ["restricted","retractable","supply_unlimit"]
-${ expect_json() }$
+>>> wallet_uia_update_active_flags issuer ASSSET retractable_balances true
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:45:00 PENDING   issuer              UNKNOWN             0.00000 XTS             add retractable_balances to authority pe... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 29
+OK
+
 #{ retract someone's balance }#
 
+
 #{ set "market_halt" flag }#
->>> wallet_asset_update ASSSET null null null null null null null ["restricted","retractable","market_halt","supply_unlimit"]
-${ expect_json() }$
-#{ create ask + bid txs }#
-#{ wait }#
+>>> wallet_uia_update_active_flags issuer ASSSET halted_markets true
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:45:20 PENDING   issuer              UNKNOWN             0.00000 XTS             add halted_markets to authority permsfor... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 30
+OK
+
+#{ create ask }#
+>>> wallet_market_submit_ask issuer  1 XTS 100 ASSSET
+10 assert_exception: Assert Exception
+quote_asset_rec->address_is_whitelisted( owner ):
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 31
+OK
+
+#{ create bid }#
+>>> wallet_market_submit_bid issuer  1.1 XTS 100 ASSSET
+10 assert_exception: Assert Exception
+quote_asset_rec->address_is_whitelisted( owner ):
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 32
+OK
+
 #{ ensure orders weren't executed }#
+>>> wallet_market_order_list XTS ASSSET
+
+>>> debug_advance_time 1 block
+OK
+>>> debug_wait_for_block_by_number 33
+OK
 
 #{ set "balance_halt" flag }#
->>> wallet_asset_update ASSSET null null null null null null null ["restricted","retractable","market_halt","balance_halt","supply_unlimit"]
-${ expect_json() }$
+>>> wallet_uia_update_active_flags issuer ASSSET halted_withdrawals true
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:45:30 PENDING   issuer              UNKNOWN             0.00000 XTS             add halted_withdrawals to authority perm... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
 #{ send to unauthorized }#
 #{ sent to authorized }#
 #{ create ask + bid }#
 #{ burn }#
 #{ issue }#
 
->>> debug_advance_time 1 block
-OK
->>> debug_wait_for_block_by_number 4
-OK
->>> wallet_account_balance someone
-ACCOUNT                         BALANCE                     
-============================================================
-someone                         100,000.00000 XTS           
-                                2,000.000 ASSSET            
-
 #{ remove "balance_halt" flag }#
->>> wallet_asset_update ASSSET null null null null null null null ["restricted","retractable","market_halt","supply_unlimit"]
+>>> wallet_uia_update_authority_permissions issuer ASSSET halted_withdrawals false
 ${ expect_json() }$
 
 #{ remove "restricted" flag }#
->>> wallet_asset_update ASSSET null null null null null null null ["retractable","market_halt","supply_unlimit"]
+>>> wallet_uia_update_authority_permissions issuer ASSSET restricted_deposits false
 ${ expect_json() }$
 #{ send to unauthorized }#
 #{ issue to unauthorized }#
 
 #{ remove "retractable" flag }#
->>> wallet_asset_update ASSSET null null null null null null null ["market_halt","supply_unlimit"]
+>>> wallet_uia_update_authority_permissions issuer ASSSET retractable_balances false
 ${ expect_json() }$
 #{ retract someone's balance }#
 
 #{ remove "supply_unlimit" flag }#
->>> wallet_asset_update ASSSET null null null null null null null ["market_halt"]
+>>> wallet_uia_update_authority_permissions issuer ASSSET dynamic_max_supply false
 ${ expect_json() }$
 #{ issue }#
 #{ issue to someone }#
 
 #{ remove "market_halt" flag }#
->>> wallet_asset_update ASSSET null null null null null null null []
+>>> wallet_uia_update_authority_permissions issuer ASSSET halted_markets false
 ${ expect_json() }$
 #{ wait }#
 #{ ensure orders were executed }#
 
->>> debug_advance_time 1 block
-OK
->>> debug_wait_for_block_by_number 4
-OK
 
 #{ issuer_permission can be unset (but not set) when supply > 0 }#
 #{ flags can only be set when issuer_permission is set }#
 >>> wallet_asset_update ASSSET null null null null null null null [] ["retractable","market_halt","balance_halt","supply_unlimit"]
 ${ expect_json() }$
->>> wallet_asset_update ASSSET null null null null null null null [] ["restricted","retractable","market_halt","balance_halt","supply_unlimit"]
+>>> wallet_asset_update ASSSET null null null null null null null [] ["","retractable","market_halt","balance_halt","supply_unlimit"]
 10 assert_exception: Assert Exception
 current_asset_record->issuer_permissions & restricted: 
 ${ expect_regex(r'(?s).*') }$

--- a/tests/btstests/advanced_uia/advanced_uia_tests/advanced_uia.btstest
+++ b/tests/btstests/advanced_uia/advanced_uia_tests/advanced_uia.btstest
@@ -100,6 +100,17 @@ OK
 >>> debug_wait_for_block_by_number 4
 OK
 
+#{ change fee configs to see if it fixes insufficient relay fee exception from wallet_transfer }#
+>>> wallet_uia_update_active_flags issuer ASSSET dynamic_fees true
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:41:00 PENDING   issuer              UNKNOWN             0.00000 XTS             add dynamic_fees to authority permsfor A... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
+>>> wallet_uia_update_fees issuer ASSSET 5 0.01
+TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
+======================================================================================================================================================================
+2014-06-20T14:41:00 PENDING   issuer              UNKNOWN             0.00000 XTS             update properties for ASSSET                0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
 >>> blockchain_get_asset ASSSET
 ${ expect_json() }$
 
@@ -522,6 +533,7 @@ OK
 TIMESTAMP           BLOCK     FROM                TO                  AMOUNT                  MEMO                                        FEE                 ID
 ======================================================================================================================================================================
 2014-06-20T14:45:30 PENDING   issuer              UNKNOWN             0.00000 XTS             add halted_withdrawals to authority perm... 0.50000 XTS         ${ expect_regex(r'[0-9a-f]*') }$
+
 #{ send to unauthorized }#
 #{ sent to authorized }#
 #{ create ask + bid }#


### PR DESCRIPTION
Observations:
- [x]    1) Should whitelist be able to be updated by account name? This would make using the API more simple.
- [x]    2) Unable issue to issuer account without whitelisting after restricted_deposits flag is set- should the issuer be implicitly whitelisted?
- [x]    3) Unable to wallet_transfer asset- always throws insufficient relay fee despite having shares to pay with.
- [x]    4) Submitting bid / ask for restricted asset throws exception because account name isn't considered
whitelisted.
- [x]    5) Need an API call for retracting a specified balance.