### PR TITLE
Make boost static/dynamic linking configurable - #1056

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,6 @@ LIST(APPEND BOOST_COMPONENTS thread
                              context
                              locale)
 
-set(Boost_USE_STATIC_LIBS ON)
 IF( WIN32 )
   SET(BOOST_ROOT $ENV{BOOST_ROOT})
   set(Boost_USE_MULTITHREADED ON)
@@ -181,7 +180,6 @@ else( WIN32 ) # Apple AND Linux
         endif()
     endif()
 
-    set(Boost_USE_STATIC_LIBS ON)
 endif( WIN32 )
 
 list(APPEND LEVEL_DB_SOURCES "${LEVELDB_PORT_FILE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ LIST(APPEND BOOST_COMPONENTS thread
                              unit_test_framework
                              context
                              locale)
+SET( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 
 IF( WIN32 )
   SET(BOOST_ROOT $ENV{BOOST_ROOT})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,14 @@ endif()
 
 add_definitions( -DBTS_GLOBAL_API_LOG=1 )
 
+IF(NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY MATCHES "\\.a$")
+IF(WIN32)
+add_definitions(/DBOOST_TEST_DYN_LINK)
+ELSE(WIN32)
+add_definitions(-DBOOST_TEST_DYN_LINK)
+ENDIF(WIN32)
+ENDIF()
+
 file(GLOB regression_tests_common_logs_files "${CMAKE_CURRENT_SOURCE_DIR}/regression_tests/_common_logs/*.log")
 source_group("Regression Tests\\Common Logs" FILES ${regression_tests_common_logs_files})
 
@@ -74,7 +82,6 @@ if( WIN32 )
     set(BOOST_ROOT $ENV{BOOST_ROOT})
     set(Boost_USE_DEBUG_PYTHON OFF)
     set(Boost_USE_MULTITHREADED ON)
-    set(Boost_USE_STATIC_LIBS OFF)
     set(BOOST_ALL_DYN_LINK ON) # force dynamic linking for all libraries
     find_package( Boost 1.54 REQUIRED COMPONENTS
                   thread

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 add_definitions( -DBTS_GLOBAL_API_LOG=1 )
 
-IF(NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY MATCHES "\\.a$")
+IF(NOT Boost_UNIT_TEST_FRAMEWORK_LIBRARY MATCHES "\\.(a|lib)$")
 IF(WIN32)
 add_definitions(/DBOOST_TEST_DYN_LINK)
 ELSE(WIN32)


### PR DESCRIPTION
This patch makes Boost_USE_STATIC_LIBS configurable with cmake -D ... preserving the previous default ON. Some special handling is applied to unit tests based on boost unit test framework.

Also see https://github.com/BitShares/fc/pull/5 .