### PR TITLE
Implemented whitelist for RPC calls (NOT for websocket API) - see #1421

### DIFF
--- a/libraries/client/include/bts/client/client.hpp
+++ b/libraries/client/include/bts/client/client.hpp
@@ -60,6 +60,7 @@ namespace bts { namespace client {
       std::string      encrypted_rpc_wif_key;
       fc::path         htdocs;
       map<string,bts::api::permissions> users;
+      set<string>      whitelist;
 
       bool is_valid() const; /* Currently just checks if rpc port is set */
     };
@@ -201,7 +202,7 @@ extern const std::string BTS_MESSAGE_MAGIC;
 
 FC_REFLECT(bts::client::client_notification, (timestamp)(message)(signature) )
 FC_REFLECT( bts::client::rpc_server_config, (enable)(enable_cache)(rpc_user)(rpc_password)(rpc_endpoint)(httpd_endpoint)(websocket_endpoint)
-            (encrypted_rpc_endpoint)(encrypted_rpc_wif_key)(htdocs)(users) )
+            (encrypted_rpc_endpoint)(encrypted_rpc_wif_key)(htdocs)(users)(whitelist) )
 FC_REFLECT( bts::client::chain_server_config, (enabled)(listen_port) )
 FC_REFLECT( bts::client::config,
         (logging)


### PR DESCRIPTION
My patch adds whitelisting to the http-rpc and json-rpc (encrypted and plain) interfaces. Whitelisting a commands also allows all aliases. An empty whitelist means allow-all (compatible with current default).